### PR TITLE
Set Up JWT Authentication System

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 """
 
 from pathlib import Path
+from datetime import timedelta
 import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -48,6 +49,9 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
+    'corsheaders',
     'users',
     'tailors',
     'orders',
@@ -59,6 +63,7 @@ AUTH_USER_MODEL = 'users.User'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -141,3 +146,35 @@ STATIC_URL = 'static/'
 # Media files (User uploaded files)
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
+
+# REST Framework Configuration
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 20,
+}
+
+# JWT Settings
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+}
+
+# CORS Settings
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",  # React web app (if any)
+    "http://localhost:8081",  # Expo default
+]
+
+CORS_ALLOW_CREDENTIALS = True

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -19,6 +19,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    # API endpoints will be added here
-    # path('api/', include('api.urls')),
+    path('api/auth/', include('users.urls')),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,7 @@
 Django>=4.2.0
 djangorestframework>=3.14.0
+djangorestframework-simplejwt>=5.3.0
+django-cors-headers>=4.3.0
 psycopg2-binary>=2.9.0
 django-environ>=0.11.0
 Pillow>=12.0.0

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,0 +1,44 @@
+from rest_framework import serializers
+from django.contrib.auth.password_validation import validate_password
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from .models import User
+
+
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """Custom token serializer that uses email instead of username."""
+    username_field = 'email'
+
+
+class UserRegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(
+        write_only=True,
+        required=True,
+        validators=[validate_password]
+    )
+    password2 = serializers.CharField(write_only=True, required=True)
+
+    class Meta:
+        model = User
+        fields = ('email', 'password', 'password2', 'full_name', 
+                  'phone', 'address', 'user_type')
+
+    def validate(self, attrs):
+        if attrs['password'] != attrs['password2']:
+            raise serializers.ValidationError(
+                {"password": "Password fields didn't match."}
+            )
+        return attrs
+
+    def create(self, validated_data):
+        validated_data.pop('password2')
+        user = User.objects.create_user(**validated_data)
+        return user
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'email', 'full_name', 'phone', 'address', 
+                  'profile_picture', 'user_type', 'date_joined')
+        read_only_fields = ('id', 'email', 'date_joined')
+

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,0 +1,25 @@
+from django.urls import path
+from rest_framework_simplejwt.views import (
+    TokenRefreshView,
+    TokenBlacklistView,
+)
+from rest_framework_simplejwt.views import TokenObtainPairView
+from .views import RegisterView, UserProfileView
+from .serializers import CustomTokenObtainPairSerializer
+
+
+class CustomTokenObtainPairView(TokenObtainPairView):
+    """Custom token obtain view that uses email instead of username."""
+    serializer_class = CustomTokenObtainPairSerializer
+
+
+app_name = 'users'
+
+urlpatterns = [
+    path('register/', RegisterView.as_view(), name='register'),
+    path('login/', CustomTokenObtainPairView.as_view(), name='login'),
+    path('logout/', TokenBlacklistView.as_view(), name='logout'),
+    path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('me/', UserProfileView.as_view(), name='user_profile'),
+]
+

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+from rest_framework import generics, status
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework_simplejwt.tokens import RefreshToken
+from .models import User
+from .serializers import UserRegistrationSerializer, UserSerializer
 
-# Create your views here.
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    permission_classes = (AllowAny,)
+    serializer_class = UserRegistrationSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        
+        # Generate tokens
+        refresh = RefreshToken.for_user(user)
+        
+        return Response({
+            'user': UserSerializer(user).data,
+            'tokens': {
+                'refresh': str(refresh),
+                'access': str(refresh.access_token),
+            }
+        }, status=status.HTTP_201_CREATED)
+
+
+class UserProfileView(generics.RetrieveUpdateAPIView):
+    serializer_class = UserSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_object(self):
+        return self.request.user


### PR DESCRIPTION
Closes #22

- Installed djangorestframework-simplejwt and django-cors-headers packages
- Configured JWT authentication in REST_FRAMEWORK settings with JWTAuthentication
- Added CORS middleware and configured allowed origins for localhost:3000 and localhost:8081
- Configured SIMPLE_JWT settings with 1 hour access token and 7 day refresh token lifetime
- Added token blacklist app for logout functionality
- Created UserRegistrationSerializer with password validation and matching
- Created UserSerializer for user profile data
- Created CustomTokenObtainPairSerializer to use email instead of username
- Implemented RegisterView to create users and return JWT tokens
- Implemented UserProfileView for retrieving and updating current user profile
- Created authentication endpoints: register, login, logout, refresh, and me
- Added /api/auth/ URL routing to main urls.py
- Ran migrations to create token_blacklist database tables