### PR TITLE
Implement Measurement APIs (Templates & Customer Measurements)

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/auth/', include('users.urls')),
     path('api/tailors/', include('tailors.urls')),
+    path('api/measurements/', include('measurements.urls')),
 ]

--- a/backend/measurements/serializers.py
+++ b/backend/measurements/serializers.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+from .models import MeasurementTemplate, CustomerMeasurement
+
+
+class MeasurementTemplateSerializer(serializers.ModelSerializer):
+    """Serializer for measurement templates."""
+
+    measurement_type_display = serializers.CharField(
+        source='get_measurement_type_display',
+        read_only=True
+    )
+
+    class Meta:
+        model = MeasurementTemplate
+        fields = (
+            'id', 'name', 'description', 'measurement_type',
+            'measurement_type_display', 'standard_measurements',
+            'created_at', 'updated_at'
+        )
+        read_only_fields = ('id', 'created_at', 'updated_at')
+
+
+class CustomerMeasurementSerializer(serializers.ModelSerializer):
+    """Serializer for customer measurements with template details."""
+
+    template = MeasurementTemplateSerializer(read_only=True)
+    template_id = serializers.IntegerField(write_only=True, required=False)
+    customer_name = serializers.CharField(
+        source='customer.full_name',
+        read_only=True
+    )
+
+    class Meta:
+        model = CustomerMeasurement
+        fields = (
+            'id', 'customer', 'customer_name', 'template', 'template_id',
+            'measurements', 'notes', 'created_at', 'updated_at'
+        )
+        read_only_fields = ('id', 'customer', 'created_at', 'updated_at')
+
+
+class CustomerMeasurementCreateSerializer(serializers.ModelSerializer):
+    """Serializer for creating customer measurements."""
+
+    class Meta:
+        model = CustomerMeasurement
+        fields = ('template', 'measurements', 'notes')
+
+    def validate_measurements(self, value):
+        """Validate that measurements is a dictionary."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Measurements must be a dictionary.")
+        return value
+

--- a/backend/measurements/urls.py
+++ b/backend/measurements/urls.py
@@ -1,0 +1,20 @@
+from django.urls import path
+from .views import (
+    MeasurementTemplateListView,
+    MeasurementTemplateDetailView,
+    CustomerMeasurementListView,
+    CustomerMeasurementDetailView
+)
+
+app_name = 'measurements'
+
+urlpatterns = [
+    # Template endpoints (public)
+    path('templates/', MeasurementTemplateListView.as_view(), name='template-list'),
+    path('templates/<int:id>/', MeasurementTemplateDetailView.as_view(), name='template-detail'),
+
+    # Customer measurement endpoints (authenticated)
+    path('', CustomerMeasurementListView.as_view(), name='measurement-list'),
+    path('<int:id>/', CustomerMeasurementDetailView.as_view(), name='measurement-detail'),
+]
+

--- a/backend/measurements/views.py
+++ b/backend/measurements/views.py
@@ -1,3 +1,62 @@
-from django.shortcuts import render
+from rest_framework import generics
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from .models import MeasurementTemplate, CustomerMeasurement
+from .serializers import (
+    MeasurementTemplateSerializer,
+    CustomerMeasurementSerializer,
+    CustomerMeasurementCreateSerializer
+)
 
-# Create your views here.
+
+class MeasurementTemplateListView(generics.ListAPIView):
+    """List all measurement templates."""
+
+    queryset = MeasurementTemplate.objects.all()
+    serializer_class = MeasurementTemplateSerializer
+    permission_classes = (AllowAny,)
+
+
+class MeasurementTemplateDetailView(generics.RetrieveAPIView):
+    """Get detailed information about a measurement template."""
+
+    queryset = MeasurementTemplate.objects.all()
+    serializer_class = MeasurementTemplateSerializer
+    permission_classes = (AllowAny,)
+    lookup_field = 'id'
+
+
+class CustomerMeasurementListView(generics.ListCreateAPIView):
+    """List user's measurements or create a new measurement."""
+
+    serializer_class = CustomerMeasurementSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_queryset(self):
+        """Return only the authenticated user's measurements."""
+        return CustomerMeasurement.objects.filter(
+            customer=self.request.user
+        ).select_related('template', 'customer')
+
+    def get_serializer_class(self):
+        """Use different serializer for creation."""
+        if self.request.method == 'POST':
+            return CustomerMeasurementCreateSerializer
+        return CustomerMeasurementSerializer
+
+    def perform_create(self, serializer):
+        """Set the customer to the authenticated user."""
+        serializer.save(customer=self.request.user)
+
+
+class CustomerMeasurementDetailView(generics.RetrieveUpdateDestroyAPIView):
+    """Get, update, or delete a specific measurement."""
+
+    serializer_class = CustomerMeasurementSerializer
+    permission_classes = (IsAuthenticated,)
+    lookup_field = 'id'
+
+    def get_queryset(self):
+        """Return only the authenticated user's measurements."""
+        return CustomerMeasurement.objects.filter(
+            customer=self.request.user
+        ).select_related('template', 'customer')


### PR DESCRIPTION
Closes #26

- Created MeasurementTemplateSerializer with measurement_type_display field
- Created CustomerMeasurementSerializer with nested template and customer_name
- Created CustomerMeasurementCreateSerializer with measurements validation
- Implemented MeasurementTemplateListView and MeasurementTemplateDetailView (public access)
- Implemented CustomerMeasurementListView for listing and creating user measurements
- Implemented CustomerMeasurementDetailView for retrieve, update, and delete operations
- Added URL patterns for all measurement endpoints in measurements/urls.py
- Integrated measurement URLs into core/urls.py
- Configured proper authentication and permission classes (AllowAny for templates, IsAuthenticated for customer measurements)
- Implemented user-scoped queryset filtering to ensure users can only access their own measurements
- Added query optimization with select_related for template and customer relationships